### PR TITLE
Add Glue tables for raw data and update partition by Lambda batch ingestion.

### DIFF
--- a/.github/workflows/deploy_data_ingestion.yml
+++ b/.github/workflows/deploy_data_ingestion.yml
@@ -136,6 +136,16 @@ jobs:
             cd terraform/dev
             terraform apply -auto-approve -target=module.ec2
       
+      # --- Glue Tables ---
+      - name: Terraform Plan (Glue Tables Only)
+        run: terraform plan -input=false -target=module.glue_tables
+        working-directory: terraform/dev
+
+      - name: Terraform Apply (Glue Tables Only)
+        run: |
+          cd terraform/dev
+          terraform apply -auto-approve -target=module.glue_tables
+      
       # --- Batch Ingestion ---
       - name: Terraform Plan (Batch Ingestion Only)
         run: terraform plan -input=false -target=module.batch_ingestion
@@ -166,20 +176,20 @@ jobs:
       #       cd terraform/dev
       #       terraform apply -auto-approve -target=module.streaming_ingestion
 
-      # --- Glue Crawler Raw ---
-      - name: Terraform Plan (Glue Crawler Raw Only)
-        run: terraform plan -input=false -target=module.glue_crawler_raw
-        working-directory: terraform/dev
+      # # --- Glue Crawler Raw ---
+      # - name: Terraform Plan (Glue Crawler Raw Only)
+      #   run: terraform plan -input=false -target=module.glue_crawler_raw
+      #   working-directory: terraform/dev
 
-      - name: Terraform Apply (Glue Crawler Raw Only) with Retry
-        uses: nick-fields/retry@v3
-        with:
-          timeout_minutes: 15
-          max_attempts: 3
-          retry_wait_seconds: 60
-          command: |
-            cd terraform/dev
-            terraform apply -auto-approve -target=module.glue_crawler_raw
+      # - name: Terraform Apply (Glue Crawler Raw Only) with Retry
+      #   uses: nick-fields/retry@v3
+      #   with:
+      #     timeout_minutes: 15
+      #     max_attempts: 3
+      #     retry_wait_seconds: 60
+      #     command: |
+      #       cd terraform/dev
+      #       terraform apply -auto-approve -target=module.glue_crawler_raw
 
       # --- Data Sync Raw ---
       - name: Terraform Plan (Data Sync Raw Only)

--- a/.github/workflows/deploy_data_ingestion.yml
+++ b/.github/workflows/deploy_data_ingestion.yml
@@ -27,11 +27,7 @@ jobs:
       TF_VAR_raw_bucket: insightflow-raw-bucket
       TF_VAR_clean_bucket: insightflow-clean-bucket
 
-      TF_VAR_snowflake_user: ${{ secrets.SNOWFLAKE_USER }}
-      TF_VAR_snowflake_password: ${{ secrets.SNOWFLAKE_PASSWORD }}
-      TF_VAR_snowflake_account: ${{ secrets.SNOWFLAKE_ACCOUNT }}
-      TF_VAR_snowflake_warehouse: ${{ secrets.SNOWFLAKE_WAREHOUSE }}
-      TF_VAR_snowflake_role: ${{ secrets.SNOWFLAKE_ROLE }}
+      TF_VAR_snowflake_secret_name: snowflake-insightflow
 
       TF_VAR_db_name: insightflow_imba
       TF_VAR_db_username: ${{ secrets.DB_USERNAME }}

--- a/.gitignore
+++ b/.gitignore
@@ -6,6 +6,9 @@ functions/modules/prerequisite_snowflake_data_upstream_load/.env
 *.tfstate
 *.tfstate.*
 .terraform.lock.hcl
+*.tfvars
 
 # Local test files
 test.txt
+
+.DS_Store

--- a/functions/modules/data_ingestion/batch/batch_ingestion.py
+++ b/functions/modules/data_ingestion/batch/batch_ingestion.py
@@ -2,10 +2,52 @@ import os
 import csv
 import io
 import boto3
+import json
 import snowflake.connector
 from datetime import datetime, timezone
 from dotenv import load_dotenv
 from zoneinfo import ZoneInfo
+
+def get_snowflake_credentials(secret_name):
+    """Fetch Snowflake credentials from AWS Secrets Manager"""
+    client = boto3.client("secretsmanager")
+    secret_value = client.get_secret_value(SecretId=secret_name)
+    return json.loads(secret_value["SecretString"])
+
+def add_glue_partition(glue_client, database_name, table_name, partition_values, s3_location):
+    """Add partition to Glue table with complete StorageDescriptor"""
+    try:
+        partition_input = {
+            "Values": partition_values,
+            "StorageDescriptor": {
+                "Location": s3_location,
+                "InputFormat": "org.apache.hadoop.mapred.TextInputFormat",
+                "OutputFormat": "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat",
+                "Compressed": False,
+                "SerdeInfo": {
+                    "SerializationLibrary": "org.apache.hadoop.hive.serde2.OpenCSVSerde",
+                    "Parameters": {
+                        "separatorChar": ",",
+                        "skip.header.line.count": "1"
+                    }
+                }
+            }
+        }
+        
+        glue_client.create_partition(
+            DatabaseName=database_name,
+            TableName=table_name,
+            PartitionInput=partition_input
+        )
+        print(f"✅ Added partition {partition_values} to {table_name}")
+        return True
+    except Exception as e:
+        if "Partition already exists" in str(e):
+            print(f"ℹ️ Partition {partition_values} already exists in {table_name}")
+            return True
+        else:
+            print(f"❌ Failed to add partition {partition_values} to {table_name}: {e}")
+            return False
 
 # load_dotenv()  # Local dev only, keep commented in Lambda
 
@@ -14,10 +56,21 @@ def lambda_handler(event=None, context=None):
     default_tables = ["AISLES", "DEPARTMENTS", "PRODUCTS", "ORDERS", "ORDER_PRODUCTS_PRIOR", "ORDER_PRODUCTS_TRAIN"]
     database = "INSIGHTFLOW_IMBA"   # Snowflake database name, adjust as needed
     schema = "PUBLIC"   # Snowflake schema name, adjust as needed
-    bucket = "insightflow-raw-bucket" # S3 bucket name, adjust as needed
+    bucket = os.environ.get("RAW_BUCKET", "insightflow-imba-group-raw") # S3 bucket name
     base_prefix = "data/batch"
     log_prefix = "logs/batch"
     PAGE_SIZE = 1_000_000
+    
+    # Glue configuration
+    glue_database = "insightflow_imba_raw_data_catalog"
+    glue_tables = {
+        "AISLES": "raw_aisles",
+        "DEPARTMENTS": "raw_departments", 
+        "PRODUCTS": "raw_products",
+        "ORDERS": "raw_orders",
+        "ORDER_PRODUCTS_PRIOR": "raw_order_products_prior",
+        "ORDER_PRODUCTS_TRAIN": "raw_order_products_train"
+    }
 
     # Read override tables
     tables = event.get("tables") if event and "tables" in event else default_tables
@@ -29,14 +82,19 @@ def lambda_handler(event=None, context=None):
     log_lines = []
 
     s3 = boto3.client("s3")
+    glue = boto3.client("glue")
+
+    # Get Snowflake credentials from Secrets Manager
+    secret_name = os.environ.get("SNOWFLAKE_SECRET_NAME", "snowflake-insightflow")
+    snowflake_creds = get_snowflake_credentials(secret_name)
 
     # Snowflake connect
     conn = snowflake.connector.connect(
-        user=os.getenv("SNOWFLAKE_USER"),
-        password=os.getenv("SNOWFLAKE_PASSWORD"),
-        account=os.getenv("SNOWFLAKE_ACCOUNT"),
-        warehouse=os.getenv("SNOWFLAKE_WAREHOUSE"),
-        role=os.getenv("SNOWFLAKE_ROLE"),
+        user=snowflake_creds["SNOWFLAKE_USER"],
+        password=snowflake_creds["SNOWFLAKE_PASSWORD"],
+        account=snowflake_creds["SNOWFLAKE_ACCOUNT"],
+        warehouse=snowflake_creds["SNOWFLAKE_WAREHOUSE"],
+        role=snowflake_creds["SNOWFLAKE_ROLE"],
         database=database,
         schema=schema
     )
@@ -49,6 +107,7 @@ def lambda_handler(event=None, context=None):
                 offset = 0
                 part = 0
                 total_rows = 0
+                data_uploaded = False
 
                 while True:
                     query = f"SELECT * FROM {database}.{schema}.{table_name} LIMIT {PAGE_SIZE} OFFSET {offset}"
@@ -65,7 +124,7 @@ def lambda_handler(event=None, context=None):
                     writer.writerows(rows)
                     csv_data = csv_buffer.getvalue()
 
-                    # 🆕 Update s3_key with new structure
+                    # Update s3_key with new structure
                     s3_key = f"{base_prefix}/{table_name.lower()}/{date_path}/{hhmm_path}/{table_name.lower()}_part{part}.csv"
                     s3.put_object(Bucket=bucket, Key=s3_key, Body=csv_data)
 
@@ -75,8 +134,22 @@ def lambda_handler(event=None, context=None):
                     total_rows += len(rows)
                     offset += PAGE_SIZE
                     part += 1
+                    data_uploaded = True
 
                 print(f"✅ {table_name} total: {total_rows} rows, {part} files")
+
+                # Add partition to Glue table if data was uploaded
+                if data_uploaded and table_name in glue_tables:
+                    glue_table_name = glue_tables[table_name]
+                    partition_values = [
+                        now.strftime("%Y"),  # year
+                        now.strftime("%m"),  # month
+                        now.strftime("%d"),  # day
+                        now.strftime("%H%M")  # hhmm
+                    ]
+                    s3_location = f"s3://{bucket}/{base_prefix}/{table_name.lower()}/{date_path}/{hhmm_path}/"
+                    
+                    add_glue_partition(glue, glue_database, glue_table_name, partition_values, s3_location)
 
             except Exception as table_error:
                 print(f"❌ Failed to process {table_name}: {table_error}")
@@ -87,7 +160,7 @@ def lambda_handler(event=None, context=None):
         conn.close()
         print("\n✅ All tables attempted.")
 
-    # 🆕 Write log to aligned path with date/hour d
+    # Write log to aligned path with date/hour
     try:
         log_data = "\n".join(log_lines)
         log_key = f"{log_prefix}/{date_path}/{hhmm_path}/lambda_log.txt"

--- a/terraform/dev/backend.tf
+++ b/terraform/dev/backend.tf
@@ -2,7 +2,7 @@
 
 terraform {
   backend "s3" {
-    bucket         = "insightflow-imba-group-state"
+    bucket         = "insightflow-imba-group-state-22"
     key            = "state/terraform.tfstate"
     region         = "ap-southeast-2"
     dynamodb_table = "insightflow_imba_group"

--- a/terraform/dev/backend.tf
+++ b/terraform/dev/backend.tf
@@ -2,7 +2,7 @@
 
 terraform {
   backend "s3" {
-    bucket         = "insightflow-imba-group-state-22"
+    bucket         = "insightflow-imba-group-state"
     key            = "state/terraform.tfstate"
     region         = "ap-southeast-2"
     dynamodb_table = "insightflow_imba_group"

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -22,6 +22,16 @@ module "vpc" {
   region               = var.aws_region
 }
 
+# Glue Tables
+module "glue_tables" {
+  source = "../modules/glue_tables"
+
+  env                = "insightflow_dev"
+  s3_raw_bucket_name = var.raw_bucket
+  s3_raw_data_prefix = var.raw_prefix
+  raw_database_name  = "insightflow_imba_raw_data_catalog"
+  depends_on         = [module.s3_buckets]
+}
 
 module "batch_ingestion" {
   source = "../modules/data_ingestion/batch"
@@ -39,18 +49,17 @@ module "batch_ingestion" {
   eventbridge_schedule_expression = "cron(0 14 30 * ? *)"
   # 根据最后的项目需求调整
 
-  snowflake_user      = var.snowflake_user
-  snowflake_password  = var.snowflake_password
-  snowflake_account   = var.snowflake_account
-  snowflake_warehouse = var.snowflake_warehouse
-  snowflake_role      = var.snowflake_role
 
-  aws_region   = var.aws_region
-  raw_bucket   = var.raw_bucket
-  clean_bucket = var.clean_bucket
+  snowflake_secret_name = var.snowflake_secret_name
+
+  aws_region        = var.aws_region
+  raw_bucket        = var.raw_bucket
+  clean_bucket      = var.clean_bucket
+  raw_database_arn  = module.glue_tables.raw_database_arn
+  raw_database_name = module.glue_tables.raw_database_name
 
   # 确保 S3 bucket 相关资源先于数据采集模块创建
-  depends_on = [module.s3_buckets]
+  depends_on = [module.s3_buckets, module.glue_tables]
 }
 
 module "streaming_ingestion" {
@@ -114,28 +123,30 @@ module "rds_postgresql" {
 # =============================
 # Glue Crawler for Raw Data
 # =============================
-module "glue_crawler_raw" {
-  source = "../modules/glue_crawler_raw"
+# module "glue_crawler_raw" {
+#   source = "../modules/glue_crawler_raw"
 
-  env                = "insightflow_dev"
-  s3_bucket_name     = var.raw_bucket
-  s3_raw_data_prefix = var.raw_prefix
-  database_name      = "insightflow_imba_raw_data_catalog"
-  table_prefix       = "raw_"
-  recrawl_behavior   = var.recrawl_behavior
+#   env                = "insightflow_dev"
+#   s3_bucket_name     = var.raw_bucket
+#   s3_raw_data_prefix = var.raw_prefix
+#   database_name      = "insightflow_imba_raw_data_catalog"
+#   table_prefix       = "raw_"
+#   recrawl_behavior   = var.recrawl_behavior
 
-  # 使用变量设置爬虫调度，而不是硬编码
-  crawler_schedule = var.crawler_schedule
+#   # 使用变量设置爬虫调度，而不是硬编码
+#   crawler_schedule = var.crawler_schedule
 
-  tags = {
-    Project     = "InsightFlow"
-    Environment = "insightflow_dev"
-    Owner       = "IMBADataTeam"
-    Purpose     = "RawDataCrawling"
-  }
+#   tags = {
+#     Project     = "InsightFlow"
+#     Environment = "insightflow_dev"
+#     Owner       = "IMBADataTeam"
+#     Purpose     = "RawDataCrawling"
+#   }
 
-  depends_on = [module.s3_buckets]
-}
+#   depends_on = [module.s3_buckets]
+# }
+
+
 
 module "data_sync_raw" {
   source = "../modules/data_sync/raw"

--- a/terraform/dev/outputs.tf
+++ b/terraform/dev/outputs.tf
@@ -14,27 +14,27 @@ output "rds_port" {
 # =============================
 # Glue Crawler Outputs
 # =============================
-output "glue_database_name" {
-  description = "Name of the Glue catalog database for raw data"
-  value       = module.glue_crawler_raw.glue_database_name
-}
+# output "glue_database_name" {
+#   description = "Name of the Glue catalog database for raw data"
+#   value       = module.glue_crawler_raw.glue_database_name
+# }
 
-output "glue_database_arn" {
-  description = "ARN of the Glue catalog database"
-  value       = module.glue_crawler_raw.glue_database_arn
-}
+# output "glue_database_arn" {
+#   description = "ARN of the Glue catalog database"
+#   value       = module.glue_crawler_raw.glue_database_arn
+# }
 
-output "glue_crawler_role_arn" {
-  description = "ARN of the IAM role used by Glue crawlers"
-  value       = module.glue_crawler_raw.glue_role_arn
-}
+# output "glue_crawler_role_arn" {
+#   description = "ARN of the IAM role used by Glue crawlers"
+#   value       = module.glue_crawler_raw.glue_role_arn
+# }
 
-output "glue_crawler_names" {
-  description = "Names of all created Glue crawlers"
-  value       = module.glue_crawler_raw.crawler_names
-}
+# output "glue_crawler_names" {
+#   description = "Names of all created Glue crawlers"
+#   value       = module.glue_crawler_raw.crawler_names
+# }
 
-output "glue_table_names" {
-  description = "Expected table names in the Glue catalog"
-  value       = module.glue_crawler_raw.table_names
-}
+# output "glue_table_names" {
+#   description = "Expected table names in the Glue catalog"
+#   value       = module.glue_crawler_raw.table_names
+# }

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -154,3 +154,8 @@ variable "end_ts" {
 #   type        = string
 #   default     = "100000"
 # }
+
+variable "snowflake_secret_name" {
+  description = "Snowflake secret name"
+  type        = string
+}

--- a/terraform/modules/data_ingestion/batch/iam.tf
+++ b/terraform/modules/data_ingestion/batch/iam.tf
@@ -40,6 +40,30 @@ resource "aws_iam_role_policy" "batch_ingestion_lambda_policy" {
           "arn:aws:s3:::${var.clean_bucket}",
           "arn:aws:s3:::${var.clean_bucket}/*"
         ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "secretsmanager:GetSecretValue"
+        ]
+        Resource = [
+          "arn:aws:secretsmanager:${var.aws_region}:*:secret:snowflake-insightflow*"
+        ]
+      },
+      {
+        Effect = "Allow"
+        Action = [
+          "glue:CreatePartition",
+          "glue:GetPartition",
+          "glue:GetTable",
+          "glue:GetDatabase",
+          "glue:BatchGetPartition"
+        ]
+        Resource = [
+          "arn:aws:glue:${var.aws_region}:*:catalog",
+          var.raw_database_arn,
+          "arn:aws:glue:${var.aws_region}:*:table/${var.raw_database_name}/*"
+        ]
       }
     ]
   })

--- a/terraform/modules/data_ingestion/batch/lambda.tf
+++ b/terraform/modules/data_ingestion/batch/lambda.tf
@@ -12,13 +12,9 @@ resource "aws_lambda_function" "batch_ingestion" {
 
   environment {
     variables = {
-      SNOWFLAKE_USER      = var.snowflake_user
-      SNOWFLAKE_PASSWORD  = var.snowflake_password
-      SNOWFLAKE_ACCOUNT   = var.snowflake_account
-      SNOWFLAKE_WAREHOUSE = var.snowflake_warehouse
-      SNOWFLAKE_ROLE      = var.snowflake_role
-      RAW_BUCKET          = var.raw_bucket
-      CLEAN_BUCKET        = var.clean_bucket
+      SNOWFLAKE_SECRET_NAME = var.snowflake_secret_name
+      RAW_BUCKET            = var.raw_bucket
+      CLEAN_BUCKET          = var.clean_bucket
     }
   }
 }

--- a/terraform/modules/data_ingestion/batch/variables.tf
+++ b/terraform/modules/data_ingestion/batch/variables.tf
@@ -52,29 +52,8 @@ variable "eventbridge_schedule_expression" {
   type        = string
 }
 
-variable "snowflake_user" {
-  description = "Snowflake user for Lambda environment"
-  type        = string
-}
-
-variable "snowflake_password" {
-  description = "Snowflake password for Lambda environment"
-  type        = string
-  sensitive   = true
-}
-
-variable "snowflake_account" {
-  description = "Snowflake account identifier"
-  type        = string
-}
-
-variable "snowflake_warehouse" {
-  description = "Snowflake warehouse name"
-  type        = string
-}
-
-variable "snowflake_role" {
-  description = "Snowflake role"
+variable "snowflake_secret_name" {
+  description = "Snowflake secret name"
   type        = string
 }
 
@@ -90,5 +69,15 @@ variable "raw_bucket" {
 
 variable "clean_bucket" {
   description = "S3 bucket for clean data"
+  type        = string
+}
+
+variable "raw_database_arn" {
+  description = "ARN of the Glue catalog database for raw data"
+  type        = string
+}
+
+variable "raw_database_name" {
+  description = "Name of the Glue catalog database for raw data"
   type        = string
 }

--- a/terraform/modules/glue_crawler_raw/glue_crawler.tf
+++ b/terraform/modules/glue_crawler_raw/glue_crawler.tf
@@ -1,19 +1,4 @@
-# =============================
-# 简化版增量爬取 AWS Glue Crawlers 
-# 专注于核心增量功能，去除复杂配置
-# =============================
 
-# Glue Catalog Database
-resource "aws_glue_catalog_database" "raw_data_catalog" {
-  name        = var.database_name
-  description = "简化版原始数据目录 - 支持增量爬取"
-
-  tags = merge(var.tags, {
-    Name        = var.database_name
-    Environment = var.env
-    Purpose     = "SimpleIncrementalCrawling"
-  })
-}
 
 # =============================
 # 简化版增量爬虫 - 只保留核心功能

--- a/terraform/modules/glue_tables/glue_tables.tf
+++ b/terraform/modules/glue_tables/glue_tables.tf
@@ -1,0 +1,103 @@
+# =============================
+# 简化版增量爬取 AWS Glue Crawlers 
+# 专注于核心增量功能，去除复杂配置
+# =============================
+
+# Glue Catalog Database
+resource "aws_glue_catalog_database" "raw_data_catalog" {
+  name        = var.raw_database_name
+  description = "简化版原始数据目录 - 支持增量爬取"
+
+  tags = merge(var.tags, {
+    Name        = var.raw_database_name
+    Environment = var.env
+    Purpose     = "SimpleIncrementalCrawling"
+  })
+}
+
+locals {
+  raw_data_path = "s3://${var.s3_raw_bucket_name}/${var.s3_raw_data_prefix}"
+}
+
+module "departments_table" {
+  source        = "./table"
+  name          = "${var.raw_table_prefix}departments"
+  database_name = var.raw_database_name
+  location      = "${local.raw_data_path}/departments/"
+  columns = [
+    { name = "department_id", type = "int" },
+    { name = "department", type = "string" }
+  ]
+  depends_on = [aws_glue_catalog_database.raw_data_catalog]
+}
+
+module "aisles_table" {
+  source        = "./table"
+  name          = "${var.raw_table_prefix}aisles"
+  database_name = var.raw_database_name
+  location      = "${local.raw_data_path}/aisles/"
+  columns = [
+    { name = "aisle_id", type = "int" },
+    { name = "aisle", type = "string" }
+  ]
+  depends_on = [aws_glue_catalog_database.raw_data_catalog]
+}
+
+module "products_table" {
+  source        = "./table"
+  name          = "${var.raw_table_prefix}products"
+  database_name = var.raw_database_name
+  location      = "${local.raw_data_path}/products/"
+  columns = [
+    { name = "product_id", type = "int" },
+    { name = "product_name", type = "string" },
+    { name = "aisle_id", type = "int" },
+    { name = "department_id", type = "int" }
+  ]
+  depends_on = [aws_glue_catalog_database.raw_data_catalog]
+}
+
+module "orders_table" {
+  source        = "./table"
+  name          = "${var.raw_table_prefix}orders"
+  database_name = var.raw_database_name
+  location      = "${local.raw_data_path}/orders/"
+  columns = [
+    { name = "order_id", type = "int" },
+    { name = "user_id", type = "int" },
+    { name = "eval_set", type = "string" },
+    { name = "order_number", type = "int" },
+    { name = "order_dow", type = "int" },
+    { name = "order_hour_of_day", type = "int" },
+    { name = "days_since_prior", type = "int" }
+  ]
+  depends_on = [aws_glue_catalog_database.raw_data_catalog]
+}
+
+module "order_products__prior_table" {
+  source        = "./table"
+  name          = "${var.raw_table_prefix}order_products_prior"
+  database_name = var.raw_database_name
+  location      = "${local.raw_data_path}/order_products_prior/"
+  columns = [
+    { name = "order_id", type = "int" },
+    { name = "product_id", type = "int" },
+    { name = "add_to_cart_order", type = "int" },
+    { name = "reordered", type = "string" }
+  ]
+  depends_on = [aws_glue_catalog_database.raw_data_catalog]
+}
+
+module "order_products__train_table" {
+  source        = "./table"
+  name          = "${var.raw_table_prefix}order_products_train"
+  database_name = var.raw_database_name
+  location      = "${local.raw_data_path}/order_products_train/"
+  columns = [
+    { name = "order_id", type = "int" },
+    { name = "product_id", type = "int" },
+    { name = "add_to_cart_order", type = "int" },
+    { name = "reordered", type = "string" }
+  ]
+  depends_on = [aws_glue_catalog_database.raw_data_catalog]
+}

--- a/terraform/modules/glue_tables/outputs.tf
+++ b/terraform/modules/glue_tables/outputs.tf
@@ -1,0 +1,7 @@
+output "raw_database_arn" {
+  value = aws_glue_catalog_database.raw_data_catalog.arn
+}
+
+output "raw_database_name" {
+  value = aws_glue_catalog_database.raw_data_catalog.name
+}

--- a/terraform/modules/glue_tables/table/main.tf
+++ b/terraform/modules/glue_tables/table/main.tf
@@ -1,0 +1,50 @@
+resource "aws_glue_catalog_table" "csv_table" {
+  name          = var.name
+  database_name = var.database_name
+  table_type    = "EXTERNAL_TABLE"
+
+  parameters = {
+    classification = "csv"
+  }
+
+  storage_descriptor {
+    location      = var.location
+    input_format  = "org.apache.hadoop.mapred.TextInputFormat"
+    output_format = "org.apache.hadoop.hive.ql.io.HiveIgnoreKeyTextOutputFormat"
+    compressed    = false
+
+    ser_de_info {
+      serialization_library = "org.apache.hadoop.hive.serde2.OpenCSVSerde"
+      parameters = {
+        "separatorChar"          = ","
+        "skip.header.line.count" = "1"
+      }
+    }
+
+    dynamic "columns" {
+      for_each = var.columns
+      content {
+        name = columns.value.name
+        type = columns.value.type
+      }
+    }
+  }
+
+  # Add partition keys for year, month, day, hhmm
+  partition_keys {
+    name = "year"
+    type = "string"
+  }
+  partition_keys {
+    name = "month"
+    type = "string"
+  }
+  partition_keys {
+    name = "day"
+    type = "string"
+  }
+  partition_keys {
+    name = "hhmm"
+    type = "string"
+  }
+}

--- a/terraform/modules/glue_tables/table/variables.tf
+++ b/terraform/modules/glue_tables/table/variables.tf
@@ -1,0 +1,26 @@
+variable "name" {
+  type = string
+}
+
+variable "database_name" {
+  type = string
+}
+
+variable "location" {
+  description = "S3 location for the table data"
+  type        = string
+}
+
+variable "columns" {
+  description = "List of columns for the Glue table"
+  type = list(object({
+    name = string
+    type = string
+  }))
+}
+
+variable "compression_type" {
+  description = "Compression type for the table (not used for CSV)"
+  type        = string
+  default     = "none"
+}

--- a/terraform/modules/glue_tables/variables.tf
+++ b/terraform/modules/glue_tables/variables.tf
@@ -1,0 +1,29 @@
+variable "env" {
+  description = "Environment"
+  type        = string
+}
+
+variable "tags" {
+  description = "Tags"
+  type        = map(string)
+  default     = {}
+}
+
+variable "s3_raw_bucket_name" {
+  type = string
+}
+
+variable "s3_raw_data_prefix" {
+  type    = string
+  default = "data/batch"
+}
+
+variable "raw_database_name" {
+  type = string
+}
+
+variable "raw_table_prefix" {
+  description = "Prefix for all tables created by crawlers"
+  type        = string
+  default     = "raw_"
+}


### PR DESCRIPTION
 Add Glue tables of raw data and update partition by Lambda batch ingestion.
- Glue tables module
- Lambda batch ingestion updates table partition when ingesting data into S3
- Comment out Crawler
- Create Glue tables first and then run batch ingestion.

 Add secret manager manager to handle Snowflake credentials in batch ingestion.
- The secret name "snowflake-insightflow" was added in AWS Secret Manager
- Add corresponding IAM and environment variable to lambda