### PR TITLE
feat: Add Step Functions data pipeline with EventBridge automation

### DIFF
--- a/.github/workflows/deploy_etl_pipeline.yml
+++ b/.github/workflows/deploy_etl_pipeline.yml
@@ -287,7 +287,7 @@ jobs:
             cd terraform/dev
             terraform apply -auto-approve -target=module.glue_crawler_transformation
 
-      # --- Step Functions ---
+      # --- Step Functions ---d
       - name: Terraform Plan (Step Functions Only)
         run: terraform plan -input=false -target=module.step_functions
         working-directory: terraform/dev

--- a/.github/workflows/deploy_etl_pipeline.yml
+++ b/.github/workflows/deploy_etl_pipeline.yml
@@ -287,6 +287,26 @@ jobs:
             cd terraform/dev
             terraform apply -auto-approve -target=module.glue_crawler_transformation
 
+      # --- Step Functions ---
+      - name: Terraform Plan (Step Functions Only)
+        run: terraform plan -input=false -target=module.step_functions
+        working-directory: terraform/dev
+
+      - name: Terraform Apply (Step Functions Only) with Retry
+        uses: nick-fields/retry@v3
+        with:
+          timeout_minutes: 15
+          max_attempts: 3
+          retry_wait_seconds: 60
+          command: |
+            cd terraform/dev
+            terraform apply -auto-approve -target=module.step_functions
+
+      # --- Trigger Step Functions ---
+      - name: Trigger Step Functions Workflow
+        run: |
+          make execute-pipeline
+          
       # =============================
       # Temporarily Disabled Modules
       # =============================

--- a/Makefile
+++ b/Makefile
@@ -1,0 +1,32 @@
+# ======================================================
+# Execute Step Function Pipeline
+# ======================================================
+execute-pipeline:
+	@echo "🚀 Starting InsightFlow Data Pipeline..."
+	@cd terraform/dev && \
+	ARN=$$(terraform output -raw step_functions_state_machine_arn 2>/dev/null) && \
+	cd ../.. && \
+	if [ -z "$$ARN" ]; then \
+		echo "❌ Error: No Step Functions ARN found. Run 'make apply' first." && \
+		exit 1; \
+	fi && \
+	echo "📋 Starting execution..." && \
+	EXECUTION_ARN=$$(aws stepfunctions start-execution \
+		--profile insightflow \
+		--state-machine-arn "$$ARN" \
+		--name "pipeline-$$(date +%s)" \
+		--query 'executionArn' \
+		--output text) && \
+	echo "⏳ Waiting for completion..." && \
+	while [ "$$(aws stepfunctions describe-execution --profile insightflow --execution-arn "$$EXECUTION_ARN" --query 'status' --output text)" = "RUNNING" ]; do \
+		echo "⏳ Running... $$(date)"; \
+		sleep 30; \
+	done && \
+	STATUS=$$(aws stepfunctions describe-execution --profile insightflow --execution-arn "$$EXECUTION_ARN" --query 'status' --output text) && \
+	if [ "$$STATUS" = "SUCCEEDED" ]; then \
+		echo "✅ Pipeline completed successfully!"; \
+	else \
+		echo "❌ Pipeline failed with status: $$STATUS" && \
+		aws stepfunctions describe-execution --profile insightflow --execution-arn "$$EXECUTION_ARN" && \
+		exit 1; \
+	fi

--- a/terraform/dev/backend.tf
+++ b/terraform/dev/backend.tf
@@ -7,10 +7,7 @@ terraform {
     region         = "ap-southeast-2"
     dynamodb_table = "insightflow_imba_group"
     encrypt        = true
+    profile        = "insightflow"
   }
 }
-# terraform {
-#   backend "local" {
-#     path = "terraform.tfstate"
-#   }
-# }
+

--- a/terraform/dev/main.tf
+++ b/terraform/dev/main.tf
@@ -3,6 +3,7 @@
 
 provider "aws" {
   region = var.aws_region
+  # profile = "insightflow"  # aws cli credential profile
 }
 
 data "aws_caller_identity" "current" {}
@@ -366,4 +367,20 @@ module "glue_crawler_transformation" {
   }
 
   depends_on = [module.s3_buckets, module.etl_data_transformation]
+}
+
+# =============================
+# Step Functions Module
+# =============================
+module "step_functions" {
+  source                             = "../modules/step_functions"
+  batch_ingestion_lambda_name        = module.batch_ingestion.batch_ingestion_lambda_function_name
+  etl_glue_job_name                  = module.etl_data_transformation.etl_glue_job_name
+  clean_glue_job_name                = module.etl_data_clean.data_clean_glue_job_name
+  crawler_names                      = module.glue_crawler_transformation.crawler_names
+  sf_eventbridge_schedule_expression = var.sf_eventbridge_schedule_expression
+
+  env = "dev"
+
+  depends_on = [module.batch_ingestion, module.etl_data_transformation, module.etl_data_clean, module.glue_crawler_transformation]
 }

--- a/terraform/dev/outputs.tf
+++ b/terraform/dev/outputs.tf
@@ -48,22 +48,22 @@ output "vpc_id" {
 # =============================
 # ETL Data Clean Outputs
 # =============================
-output "etl_glue_job_name" {
+output "clean_glue_job_name" {
   description = "Name of the ETL Data Clean Glue Job"
-  value       = module.etl_data_clean.glue_job_name
+  value       = module.etl_data_clean.data_clean_glue_job_name
 }
 
-output "etl_glue_job_arn" {
+output "clean_glue_job_arn" {
   description = "ARN of the ETL Data Clean Glue Job"
-  value       = module.etl_data_clean.glue_job_arn
+  value       = module.etl_data_clean.data_clean_glue_job_arn
 }
 
-output "etl_iam_role_arn" {
+output "clean_iam_role_arn" {
   description = "ARN of the IAM Role for ETL Data Clean Glue Job"
   value       = module.etl_data_clean.iam_role_arn
 }
 
-output "etl_iam_role_name" {
+output "clean_iam_role_name" {
   description = "Name of the IAM Role for ETL Data Clean Glue Job"
   value       = module.etl_data_clean.iam_role_name
 }
@@ -97,3 +97,16 @@ output "etl_iam_role_name" {
 #   description = "S3 path for the combined table output"
 #   value       = var.table_combine_output_path
 # }
+
+# =============================
+# Step Functions Outputs
+# =============================
+output "step_functions_state_machine_arn" {
+  description = "ARN of the Step Functions state machine"
+  value       = module.step_functions.step_functions_state_machine_arn
+}
+
+output "step_functions_state_machine_name" {
+  description = "Name of the Step Functions state machine"
+  value       = module.step_functions.step_functions_state_machine_name
+}

--- a/terraform/dev/variables.tf
+++ b/terraform/dev/variables.tf
@@ -344,3 +344,12 @@ variable "transformation_crawler_schedule" {
   type        = string
   default     = "cron(0 17 30 * ? *)" # UTC时间每月30日下午5点运行，在 transformation job 完成后
 }
+
+# =============================
+# Step Functions Variables
+# =============================
+variable "sf_eventbridge_schedule_expression" {
+  description = "Schedule expression for EventBridge rule (e.g., 'rate(1 hour)' or 'cron(0 2 * * ? *)' (2 AM every day))"
+  type        = string
+  default     = "cron(0 16 30 * ? *)"
+}

--- a/terraform/dev/version.tf
+++ b/terraform/dev/version.tf
@@ -4,7 +4,7 @@ terraform {
   required_providers {
     aws = {
       source  = "hashicorp/aws"
-      version = "~> 5.0"
+      version = "~> 6.0"
     }
   }
 }

--- a/terraform/modules/ETL/data_clean/outputs.tf
+++ b/terraform/modules/ETL/data_clean/outputs.tf
@@ -1,9 +1,9 @@
-output "glue_job_name" {
+output "data_clean_glue_job_name" {
   description = "The name of the Glue Job for data cleaning."
   value       = aws_glue_job.data_clean.name
 }
 
-output "glue_job_arn" {
+output "data_clean_glue_job_arn" {
   description = "The ARN of the Glue Job for data cleaning."
   value       = aws_glue_job.data_clean.arn
 }

--- a/terraform/modules/ETL/data_transformation/outputs.tf
+++ b/terraform/modules/ETL/data_transformation/outputs.tf
@@ -1,9 +1,9 @@
-output "job_name" {
+output "etl_glue_job_name" {
   description = "Name of the ETL Data Transformation Glue Job"
   value       = aws_glue_job.data_transformation.name
 }
 
-output "job_arn" {
+output "etl_glue_job_arn" {
   description = "ARN of the ETL Data Transformation Glue Job"
   value       = aws_glue_job.data_transformation.arn
 }

--- a/terraform/modules/data_ingestion/batch/output.tf
+++ b/terraform/modules/data_ingestion/batch/output.tf
@@ -1,0 +1,7 @@
+output "batch_ingestion_lambda_function_name" {
+  value = aws_lambda_function.batch_ingestion.function_name
+}
+
+output "batch_ingestion_lambda_function_arn" {
+  value = aws_lambda_function.batch_ingestion.arn
+}

--- a/terraform/modules/step_functions/eventbridge.tf
+++ b/terraform/modules/step_functions/eventbridge.tf
@@ -1,0 +1,82 @@
+# EventBridge configuration to trigger Step Functions state machine
+
+# EventBridge Rule
+resource "aws_cloudwatch_event_rule" "step_functions_trigger" {
+  name                = var.sf_eventbridge_rule_name
+  description         = var.sf_eventbridge_rule_description
+  schedule_expression = var.sf_eventbridge_schedule_expression
+
+  tags = {
+    Name        = var.sf_eventbridge_rule_name
+    Environment = var.env
+    Project     = "InsightFlow"
+  }
+}
+
+# IAM Role for EventBridge to invoke Step Functions
+resource "aws_iam_role" "eventbridge_step_functions_role" {
+  name = "EventBridgeStepFunctionsRole-${var.env}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Principal = {
+          Service = "events.amazonaws.com"
+        }
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+
+  tags = {
+    Name        = "EventBridgeStepFunctionsRole-${var.env}"
+    Environment = var.env
+    Project     = "InsightFlow"
+  }
+}
+
+# IAM Policy for EventBridge to invoke Step Functions
+resource "aws_iam_policy" "eventbridge_step_functions_policy" {
+  name        = "EventBridgeStepFunctionsPolicy-${var.env}"
+  description = "Policy for EventBridge to invoke Step Functions state machine"
+
+  policy = jsonencode({
+    Version = "2012-10-17"
+    Statement = [
+      {
+        Effect = "Allow"
+        Action = [
+          "states:StartExecution"
+        ]
+        Resource = [
+          aws_sfn_state_machine.data_pipeline.arn
+        ]
+      }
+    ]
+  })
+}
+
+# Attach policy to role
+resource "aws_iam_role_policy_attachment" "eventbridge_step_functions_policy_attach" {
+  role       = aws_iam_role.eventbridge_step_functions_role.name
+  policy_arn = aws_iam_policy.eventbridge_step_functions_policy.arn
+}
+
+# EventBridge Target to invoke Step Functions
+resource "aws_cloudwatch_event_target" "step_functions_target" {
+  rule      = aws_cloudwatch_event_rule.step_functions_trigger.name
+  target_id = "StepFunctionsTarget"
+  arn       = aws_sfn_state_machine.data_pipeline.arn
+  role_arn  = aws_iam_role.eventbridge_step_functions_role.arn
+
+  input_transformer {
+    input_paths = {}
+    input_template = jsonencode({
+      "executionName" = "scheduled-execution-$${aws:events:rule-name}-$${aws:events:event-id}"
+      "timestamp"     = "$${aws:events:event-time}"
+    })
+  }
+}
+

--- a/terraform/modules/step_functions/outputs.tf
+++ b/terraform/modules/step_functions/outputs.tf
@@ -1,0 +1,23 @@
+output "step_functions_state_machine_arn" {
+  value = aws_sfn_state_machine.data_pipeline.arn
+}
+
+output "step_functions_state_machine_name" {
+  value = aws_sfn_state_machine.data_pipeline.name
+}
+
+# EventBridge Outputs
+output "eventbridge_rule_arn" {
+  description = "ARN of the EventBridge rule"
+  value       = aws_cloudwatch_event_rule.step_functions_trigger.arn
+}
+
+output "eventbridge_rule_name" {
+  description = "Name of the EventBridge rule"
+  value       = aws_cloudwatch_event_rule.step_functions_trigger.name
+}
+
+output "eventbridge_role_arn" {
+  description = "ARN of the EventBridge IAM role"
+  value       = aws_iam_role.eventbridge_step_functions_role.arn
+}

--- a/terraform/modules/step_functions/state-machine.json
+++ b/terraform/modules/step_functions/state-machine.json
@@ -1,0 +1,390 @@
+{
+  "Comment": "Data Pipeline: Lambda Batch Ingestion -> Glue Clean Data -> Glue ETL -> Parallel Crawlers",
+  "StartAt": "BatchIngestion",
+  "States": {
+    "BatchIngestion": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::lambda:invoke",
+      "Parameters": {
+        "FunctionName": "${batch_ingestion_lambda_name}"
+      },
+      "ResultPath": "$.batchIngestionResult",
+      "Next": "CleanDataJob",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "BatchIngestionFailed",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+    "BatchIngestionFailed": {
+      "Type": "Fail",
+      "Cause": "Batch ingestion failed",
+      "Error": "BatchIngestionError"
+    },
+    "CleanDataJob": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "${clean_glue_job_name}"
+      },
+      "ResultPath": "$.cleanDataResult",
+      "Next": "ETLJob",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "CleanDataFailed",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+    "CleanDataFailed": {
+      "Type": "Fail",
+      "Cause": "Clean data job failed",
+      "Error": "CleanDataError"
+    },
+    "ETLJob": {
+      "Type": "Task",
+      "Resource": "arn:aws:states:::glue:startJobRun.sync",
+      "Parameters": {
+        "JobName": "${etl_glue_job_name}"
+      },
+      "ResultPath": "$.etlResult",
+      "Next": "StartAllCrawlers",
+      "Catch": [
+        {
+          "ErrorEquals": ["States.ALL"],
+          "Next": "ETLFailed",
+          "ResultPath": "$.error"
+        }
+      ]
+    },
+    "ETLFailed": {
+      "Type": "Fail",
+      "Cause": "ETL job failed",
+      "Error": "ETLError"
+    },
+    "StartAllCrawlers": {
+      "Type": "Parallel",
+      "Branches": [
+        {
+          "StartAt": "StartUserFeaturesCrawler",
+          "States": {
+            "StartUserFeaturesCrawler": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_0}"
+              },
+              "ResultPath": "$.userFeaturesCrawlerResult",
+              "Next": "WaitForUserFeaturesCrawler"
+            },
+            "WaitForUserFeaturesCrawler": {
+              "Type": "Wait",
+              "Seconds": 30,
+              "Next": "CheckUserFeaturesCrawlerStatus"
+            },
+            "CheckUserFeaturesCrawlerStatus": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:getCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_0}"
+              },
+              "ResultPath": "$.userFeaturesCrawlerStatus",
+              "Next": "UserFeaturesCrawlerComplete?"
+            },
+            "UserFeaturesCrawlerComplete?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.userFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "READY",
+                  "Next": "UserFeaturesCrawlerSuccess"
+                },
+                {
+                  "Variable": "$.userFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPING",
+                  "Next": "WaitForUserFeaturesCrawler"
+                },
+                {
+                  "Variable": "$.userFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "RUNNING",
+                  "Next": "WaitForUserFeaturesCrawler"
+                },
+                {
+                  "Variable": "$.userFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPED",
+                  "Next": "UserFeaturesCrawlerSuccess"
+                }
+              ],
+              "Default": "UserFeaturesCrawlerFailed"
+            },
+            "UserFeaturesCrawlerSuccess": {
+              "Type": "Succeed"
+            },
+            "UserFeaturesCrawlerFailed": {
+              "Type": "Fail",
+              "Cause": "User Features Crawler failed",
+              "Error": "UserFeaturesCrawlerError"
+            }
+          }
+        },
+        {
+          "StartAt": "StartProductFeaturesCrawler",
+          "States": {
+            "StartProductFeaturesCrawler": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_1}"
+              },
+              "ResultPath": "$.productFeaturesCrawlerResult",
+              "Next": "WaitForProductFeaturesCrawler"
+            },
+            "WaitForProductFeaturesCrawler": {
+              "Type": "Wait",
+              "Seconds": 30,
+              "Next": "CheckProductFeaturesCrawlerStatus"
+            },
+            "CheckProductFeaturesCrawlerStatus": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:getCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_1}"
+              },
+              "ResultPath": "$.productFeaturesCrawlerStatus",
+              "Next": "ProductFeaturesCrawlerComplete?"
+            },
+            "ProductFeaturesCrawlerComplete?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.productFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "READY",
+                  "Next": "ProductFeaturesCrawlerSuccess"
+                },
+                {
+                  "Variable": "$.productFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPING",
+                  "Next": "WaitForProductFeaturesCrawler"
+                },
+                {
+                  "Variable": "$.productFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "RUNNING",
+                  "Next": "WaitForProductFeaturesCrawler"
+                },
+                {
+                  "Variable": "$.productFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPED",
+                  "Next": "ProductFeaturesCrawlerSuccess"
+                }
+              ],
+              "Default": "ProductFeaturesCrawlerFailed"
+            },
+            "ProductFeaturesCrawlerSuccess": {
+              "Type": "Succeed"
+            },
+            "ProductFeaturesCrawlerFailed": {
+              "Type": "Fail",
+              "Cause": "Product Features Crawler failed",
+              "Error": "ProductFeaturesCrawlerError"
+            }
+          }
+        },
+        {
+          "StartAt": "StartUPIFeaturesCrawler",
+          "States": {
+            "StartUPIFeaturesCrawler": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_2}"
+              },
+              "ResultPath": "$.upiFeaturesCrawlerResult",
+              "Next": "WaitForUPIFeaturesCrawler"
+            },
+            "WaitForUPIFeaturesCrawler": {
+              "Type": "Wait",
+              "Seconds": 30,
+              "Next": "CheckUPIFeaturesCrawlerStatus"
+            },
+            "CheckUPIFeaturesCrawlerStatus": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:getCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_2}"
+              },
+              "ResultPath": "$.upiFeaturesCrawlerStatus",
+              "Next": "UPIFeaturesCrawlerComplete?"
+            },
+            "UPIFeaturesCrawlerComplete?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.upiFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "READY",
+                  "Next": "UPIFeaturesCrawlerSuccess"
+                },
+                {
+                  "Variable": "$.upiFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPING",
+                  "Next": "WaitForUPIFeaturesCrawler"
+                },
+                {
+                  "Variable": "$.upiFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "RUNNING",
+                  "Next": "WaitForUPIFeaturesCrawler"
+                },
+                {
+                  "Variable": "$.upiFeaturesCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPED",
+                  "Next": "UPIFeaturesCrawlerSuccess"
+                }
+              ],
+              "Default": "UPIFeaturesCrawlerFailed"
+            },
+            "UPIFeaturesCrawlerSuccess": {
+              "Type": "Succeed"
+            },
+            "UPIFeaturesCrawlerFailed": {
+              "Type": "Fail",
+              "Cause": "UPI Features Crawler failed",
+              "Error": "UPIFeaturesCrawlerError"
+            }
+          }
+        },
+        {
+          "StartAt": "StartProductFeaturesUnionCrawler",
+          "States": {
+            "StartProductFeaturesUnionCrawler": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_3}"
+              },
+              "ResultPath": "$.productFeaturesUnionCrawlerResult",
+              "Next": "WaitForProductFeaturesUnionCrawler"
+            },
+            "WaitForProductFeaturesUnionCrawler": {
+              "Type": "Wait",
+              "Seconds": 30,
+              "Next": "CheckProductFeaturesUnionCrawlerStatus"
+            },
+            "CheckProductFeaturesUnionCrawlerStatus": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:getCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_3}"
+              },
+              "ResultPath": "$.productFeaturesUnionCrawlerStatus",
+              "Next": "ProductFeaturesUnionCrawlerComplete?"
+            },
+            "ProductFeaturesUnionCrawlerComplete?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.productFeaturesUnionCrawlerStatus.Crawler.State",
+                  "StringEquals": "READY",
+                  "Next": "ProductFeaturesUnionCrawlerSuccess"
+                },
+                {
+                  "Variable": "$.productFeaturesUnionCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPING",
+                  "Next": "WaitForProductFeaturesUnionCrawler"
+                },
+                {
+                  "Variable": "$.productFeaturesUnionCrawlerStatus.Crawler.State",
+                  "StringEquals": "RUNNING",
+                  "Next": "WaitForProductFeaturesUnionCrawler"
+                },
+                {
+                  "Variable": "$.productFeaturesUnionCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPED",
+                  "Next": "ProductFeaturesUnionCrawlerSuccess"
+                }
+              ],
+              "Default": "ProductFeaturesUnionCrawlerFailed"
+            },
+            "ProductFeaturesUnionCrawlerSuccess": {
+              "Type": "Succeed"
+            },
+            "ProductFeaturesUnionCrawlerFailed": {
+              "Type": "Fail",
+              "Cause": "Product Features Union Crawler failed",
+              "Error": "ProductFeaturesUnionCrawlerError"
+            }
+          }
+        },
+        {
+          "StartAt": "StartUPIFeaturesUnionCrawler",
+          "States": {
+            "StartUPIFeaturesUnionCrawler": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:startCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_4}"
+              },
+              "ResultPath": "$.upiFeaturesUnionCrawlerResult",
+              "Next": "WaitForUPIFeaturesUnionCrawler"
+            },
+            "WaitForUPIFeaturesUnionCrawler": {
+              "Type": "Wait",
+              "Seconds": 30,
+              "Next": "CheckUPIFeaturesUnionCrawlerStatus"
+            },
+            "CheckUPIFeaturesUnionCrawlerStatus": {
+              "Type": "Task",
+              "Resource": "arn:aws:states:::aws-sdk:glue:getCrawler",
+              "Parameters": {
+                "Name": "${crawler_name_4}"
+              },
+              "ResultPath": "$.upiFeaturesUnionCrawlerStatus",
+              "Next": "UPIFeaturesUnionCrawlerComplete?"
+            },
+            "UPIFeaturesUnionCrawlerComplete?": {
+              "Type": "Choice",
+              "Choices": [
+                {
+                  "Variable": "$.upiFeaturesUnionCrawlerStatus.Crawler.State",
+                  "StringEquals": "READY",
+                  "Next": "UPIFeaturesUnionCrawlerSuccess"
+                },
+                {
+                  "Variable": "$.upiFeaturesUnionCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPING",
+                  "Next": "WaitForUPIFeaturesUnionCrawler"
+                },
+                {
+                  "Variable": "$.upiFeaturesUnionCrawlerStatus.Crawler.State",
+                  "StringEquals": "RUNNING",
+                  "Next": "WaitForUPIFeaturesUnionCrawler"
+                },
+                {
+                  "Variable": "$.upiFeaturesUnionCrawlerStatus.Crawler.State",
+                  "StringEquals": "STOPPED",
+                  "Next": "UPIFeaturesUnionCrawlerSuccess"
+                }
+              ],
+              "Default": "UPIFeaturesUnionCrawlerFailed"
+            },
+            "UPIFeaturesUnionCrawlerSuccess": {
+              "Type": "Succeed"
+            },
+            "UPIFeaturesUnionCrawlerFailed": {
+              "Type": "Fail",
+              "Cause": "UPI Features Union Crawler failed",
+              "Error": "UPIFeaturesUnionCrawlerError"
+            }
+          }
+        }
+      ],
+      "ResultPath": "$.crawlersResult",
+      "Next": "PipelineSuccess"
+    },
+    "PipelineSuccess": {
+      "Type": "Succeed",
+      "Comment": "Data pipeline completed successfully"
+    }
+  }
+}

--- a/terraform/modules/step_functions/step_functions.tf
+++ b/terraform/modules/step_functions/step_functions.tf
@@ -1,0 +1,140 @@
+# Data sources for current region and account
+data "aws_region" "current" {}
+data "aws_caller_identity" "current" {}
+
+resource "aws_iam_role" "sfn_role" {
+  name = "StepFunctionsExecutionRole-${var.env}"
+
+  assume_role_policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Principal = {
+          Service = "states.amazonaws.com"
+        },
+        Action = "sts:AssumeRole"
+      }
+    ]
+  })
+}
+
+resource "aws_iam_policy" "sfn_policy" {
+  name        = "StepFunctionsPolicy-${var.env}"
+  description = "Policy for Step Functions to execute tasks"
+
+  policy = jsonencode({
+    Version = "2012-10-17",
+    Statement = [
+      {
+        Effect = "Allow",
+        Action = [
+          "glue:StartCrawler",
+          "glue:GetCrawler",
+          "glue:GetCrawlerRuns",
+          "glue:GetCrawlerMetrics"
+        ],
+        Resource = [
+          for crawler_name in var.crawler_names : "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:crawler/${crawler_name}"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "glue:StartJobRun",
+          "glue:GetJobRun",
+          "glue:GetJobRuns"
+        ],
+        Resource = [
+          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:job/${var.etl_glue_job_name}",
+          "arn:aws:glue:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:job/${var.clean_glue_job_name}"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "sagemaker:CreateTrainingJob",
+          "sagemaker:DescribeTrainingJob",
+          "sagemaker:CreateModel",
+          "sagemaker:CreateEndpointConfig",
+          "sagemaker:CreateEndpoint",
+          "sagemaker:DescribeEndpoint",
+          "sagemaker:AddTags",
+          "sagemaker:ListTags",
+          "sagemaker:StopTrainingJob"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "events:PutTargets",
+          "events:PutRule",
+          "events:DescribeRule",
+          "events:DeleteRule",
+          "events:RemoveTargets"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "iam:PassRole"
+        ],
+        Resource = "*"
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "lambda:InvokeFunction",
+          "lambda:GetFunction",
+          "lambda:GetFunctionConfiguration",
+          "lambda:ListVersionsByFunction",
+          "lambda:ListAliases"
+        ],
+        Resource = [
+          "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.batch_ingestion_lambda_name}",
+          "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:${var.batch_ingestion_lambda_name}:*"
+        ]
+      },
+      {
+        Effect = "Allow",
+        Action = [
+          "lambda:InvokeFunction"
+        ],
+        Resource = [
+          "arn:aws:lambda:${data.aws_region.current.name}:${data.aws_caller_identity.current.account_id}:function:*"
+        ]
+      }
+    ]
+  })
+}
+
+resource "aws_iam_role_policy_attachment" "sfn_policy_attach" {
+  role       = aws_iam_role.sfn_role.name
+  policy_arn = aws_iam_policy.sfn_policy.arn
+}
+
+resource "aws_sfn_state_machine" "data_pipeline" {
+  name     = "data-pipeline-${var.env}"
+  role_arn = aws_iam_role.sfn_role.arn
+
+  definition = templatefile("${path.module}/state-machine.json", {
+    batch_ingestion_lambda_name = var.batch_ingestion_lambda_name
+    clean_glue_job_name         = var.clean_glue_job_name
+    etl_glue_job_name           = var.etl_glue_job_name
+    crawler_name_0              = var.crawler_names[0]
+    crawler_name_1              = var.crawler_names[1]
+    crawler_name_2              = var.crawler_names[2]
+    crawler_name_3              = var.crawler_names[3]
+    crawler_name_4              = var.crawler_names[4]
+    env                         = var.env
+  })
+
+  tags = {
+    Name        = "data-pipeline-${var.env}"
+    Environment = var.env
+  }
+}
+
+

--- a/terraform/modules/step_functions/variables.tf
+++ b/terraform/modules/step_functions/variables.tf
@@ -1,0 +1,43 @@
+
+
+variable "batch_ingestion_lambda_name" {
+  type = string
+}
+
+variable "etl_glue_job_name" {
+  type = string
+}
+
+variable "clean_glue_job_name" {
+  type = string
+}
+
+variable "crawler_names" {
+  description = "List of crawler names to run in parallel"
+  type        = list(string)
+}
+
+
+
+variable "env" {
+  type = string
+}
+
+# EventBridge Variables
+variable "sf_eventbridge_rule_name" {
+  description = "Name of the EventBridge rule for Step Functions trigger"
+  type        = string
+  default     = "step-functions-trigger"
+}
+
+variable "sf_eventbridge_rule_description" {
+  description = "Description of the EventBridge rule for Step Functions trigger"
+  type        = string
+  default     = "Triggers Step Functions data pipeline execution"
+}
+
+variable "sf_eventbridge_schedule_expression" {
+  description = "Schedule expression for EventBridge rule (e.g., 'rate(1 hour)' or 'cron(0 2 * * ? *)' (2 AM every day))"
+  type        = string
+}
+


### PR DESCRIPTION
Add complete Step Functions module with state machine
- Implement data pipeline: Lambda → Glue Clean → Glue ETL → Parallel Crawlers
- Add EventBridge integration for automated triggering 
- Create simplified Makefile for pipeline execution
- Support for 5 parallel crawlers with proper state management
- Add Step Functions to deploy_etl_pipeline workflow

Files added:
- terraform/modules/step_functions/ (complete module)
- Makefile (pipeline execution)

Testing:
- The step machine was created on AWS ( I didn't delete it ).
- EventBridge triggers every minute for easy testing
- Manual execution via 'make execute-pipeline'

@luckyeggegg @TobbyToe @chaoyue-code @frozenpeter 
Please review and check the step function on AWS. Thank you.